### PR TITLE
Zip .env files during dev command

### DIFF
--- a/packages/saasify-cli/lib/commands/dev.js
+++ b/packages/saasify-cli/lib/commands/dev.js
@@ -23,7 +23,7 @@ module.exports = (program, client) => {
           console.log(JSON.stringify(project, null, 2))
         }
 
-        const zipBuffer = await zipProject(program, project)
+        const zipBuffer = await zipProject(program, project, true)
 
         const tempDir = await spinner(
           prepareDeployment({

--- a/packages/saasify-cli/lib/zip-project.js
+++ b/packages/saasify-cli/lib/zip-project.js
@@ -8,17 +8,29 @@ const path = require('path')
 
 const streamToBuffer = require('./stream-to-buffer')
 
-module.exports = async (program, deployment) => {
+module.exports = async (program, deployment, zipEnv = false) => {
   const files = await globby('**/*', {
     cwd: deployment.root,
     gitignore: true
   })
 
+  const envFiles = zipEnv
+    ? await globby('.env', {
+        cwd: deployment.root,
+        gitignore: false
+      })
+    : []
+
+  const allFiles = [
+    ...files,
+    ...envFiles
+  ]
+
   const mtime = new Date(1540000000000)
   const zipFile = new ZipFile()
 
   const zipBuffer = await new Promise((resolve, reject) => {
-    files
+    allFiles
       .sort()
       .forEach((file) => {
         const filePath = path.join(deployment.root, file)


### PR DESCRIPTION
When running `saasify dev` on a project containing env vars, Saasify will complain that the env vars  aren't defined, even if a `.env` file exists in the project. Upon investigation, the temporary directory didn't contain the `.env` file, since `saasify-cli` is ignoring files in the project's `.gitignore`.

This PR adds support for copying the .env file to the temporary directory during `saasify dev`.

**Security concern: wasn't 100% sure if copying the .env to the temporary directory is wise, since it has the possibility of creating copies of potentially sensitive information that will persist until temp dir is cleaned up. Alternative to copying the `.env` could be to use a symlink in the temporary directory.**