### PR TITLE
Minimizing python example

### DIFF
--- a/templates/python/main.py
+++ b/templates/python/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
 
 app = FastAPI()
 
-@app.get("/")
+
+@app.get("/{name}")
 def hello(name: str = "World"):
-  return 'Hello ' + name + '!'
+    return f"Hello {name}!"

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -1,9 +1,3 @@
-Click==7.0
-fastapi==0.41.0
-h11==0.8.1
-httptools==0.0.13
+fastapi==0.42.0
 pydantic==0.32.2
 starlette==0.12.9
-uvicorn==0.9.0
-uvloop==0.13.0
-websockets==8.0.2


### PR DESCRIPTION
Only depend on standard fastapi removing non-used dependencies, updating main to use f-string in return and taking a named optional path parameter