### PR TITLE
fix: remove massive spacing from Pricing page in waves

### DIFF
--- a/packages/react-saasify/src/themes/waves/waves.module.css
+++ b/packages/react-saasify/src/themes/waves/waves.module.css
@@ -95,6 +95,7 @@
 }
 
 .theme-waves .section .content {
+  flex: initial;
   max-width: var(--max-width);
   padding: 0 !important;
   z-index: 1;
@@ -145,6 +146,7 @@
 .theme-waves .home-page .hero-section .content {
   align-items: center;
   justify-content: center;
+  flex: 1 1;
 }
 
 @media (min-width: 48em) {


### PR DESCRIPTION
Before:
<img width="2560" alt="Screenshot 2019-11-05 16 17 13" src="https://user-images.githubusercontent.com/985961/68225082-c1796f00-ffe7-11e9-992b-31bf095e6b7d.png">

After (ignore logo):

<img width="2560" alt="Screenshot 2019-11-05 16 17 06" src="https://user-images.githubusercontent.com/985961/68225088-c2aa9c00-ffe7-11e9-8933-e44936f6bed6.png">