### PR TITLE
fix: ensure image previews are flush

### DIFF
--- a/packages/react-saasify/src/components/LiveServiceDemo/styles.module.css
+++ b/packages/react-saasify/src/components/LiveServiceDemo/styles.module.css
@@ -98,14 +98,8 @@
   text-align: center;
 }
 
-.output .img-wrapper {
-  display: flex;
-  padding: 24px;
-  text-align: center;
-}
-
 .output img {
-  display: inline-block;
+  display: block;
   max-width: 100%;
   margin: 0 auto;
 }


### PR DESCRIPTION
Noticed a patch go in last night but really prefer the UI when the image is flush

From

<img width="562" alt="image" src="https://user-images.githubusercontent.com/985961/68995900-c2ac6680-0847-11ea-8cad-c0a6ff7b18d8.png">

to

<img width="572" alt="image" src="https://user-images.githubusercontent.com/985961/68995903-c809b100-0847-11ea-85e7-4afd58c93bc2.png">

Also for wordcloud:

<img width="453" alt="image" src="https://user-images.githubusercontent.com/985961/68995889-b3c5b400-0847-11ea-8e39-e66ac9597266.png">