### PR TITLE
Feat/refine wordcloud

### DIFF
--- a/examples/python/wordcloud/saasify.json
+++ b/examples/python/wordcloud/saasify.json
@@ -10,9 +10,9 @@
           "name": "News Article",
           "description": "Create wordcloud from article",
           "input": {
-            "url": "https://www.theonion.com/new-day-same-bullshit-whispers-dalai-lama-before-sl-1839720347",
-            "icon": "fas fa-flag",
-            "palette": "cartocolors.qualitative.Bold_6"
+            "url": "https://www.cbc.ca/news/canada/ottawa/snow-storm-remembrance-day-1.5355302",
+            "icon": "fab fa-canadian-maple-leaf",
+            "palette": "colorbrewer.sequential.Reds_6"
           }
         },
         {

--- a/examples/python/wordcloud/saasify.json
+++ b/examples/python/wordcloud/saasify.json
@@ -53,7 +53,8 @@
       "color": "#50A9DA",
       "wave": false,
       "gradientDark": false,
-      "codeBlockDark": true
+      "codeBlockDark": true,
+      "codeBlockOutputColor": "white"
     }
   }
 }

--- a/packages/react-saasify/src/components/LiveServiceDemo/styles.module.css
+++ b/packages/react-saasify/src/components/LiveServiceDemo/styles.module.css
@@ -98,14 +98,8 @@
   text-align: center;
 }
 
-.output .img-wrapper {
-  display: flex;
-  padding: 24px;
-  text-align: center;
-}
-
 .output img {
-  display: inline-block;
+  display: block;
   max-width: 100%;
   margin: 0 auto;
 }

--- a/packages/react-saasify/src/components/ServiceForm/ReactFromJSONSchema.js
+++ b/packages/react-saasify/src/components/ServiceForm/ReactFromJSONSchema.js
@@ -7,7 +7,7 @@ const mapProp = (prop, onChange) => {
     const { type, ...props } = prop
 
     return {
-      type,
+      type: props.enum ? 'enum' : type,
       props: {
         ...props,
         onChange,

--- a/packages/react-saasify/src/components/ServiceForm/ServiceForm.js
+++ b/packages/react-saasify/src/components/ServiceForm/ServiceForm.js
@@ -7,6 +7,7 @@ import { ServiceEntry } from './ServiceEntry'
 import { ServiceInput } from './ServiceInput'
 import { ServiceInputCheckbox } from './ServiceInputCheckbox'
 import { ServiceInputNumber } from './ServiceInputNumber'
+import { ServiceInputSelect } from './ServiceInputSelect'
 import { restrictDefinitionToExample, mergeInValues } from './helpers'
 
 import styles from './styles.module.css'
@@ -54,6 +55,7 @@ export class ServiceForm extends Component {
             ),
             entry: ServiceEntry,
             boolean: ServiceInputCheckbox,
+            enum: ServiceInputSelect,
             number: ServiceInputNumber,
             string: ServiceInput
           }}

--- a/packages/react-saasify/src/components/ServiceForm/styles.module.css
+++ b/packages/react-saasify/src/components/ServiceForm/styles.module.css
@@ -17,3 +17,12 @@
     monospace;
   font-weight: bold;
 }
+
+.service-form :global(.ant-select-selection__rendered) {
+  margin-right: 0;
+}
+
+.service-form :global(.ant-select-search__field) {
+  border: 0;
+  padding-left: 0;
+}

--- a/packages/react-saasify/src/lib/antd.js
+++ b/packages/react-saasify/src/lib/antd.js
@@ -17,6 +17,7 @@ import 'antd/es/message/style/css'
 import 'antd/es/notification/style/css'
 
 export { default as Avatar } from 'antd/es/avatar'
+export { default as AutoComplete } from 'antd/es/auto-complete'
 export { default as Button } from 'antd/es/button'
 export { default as Checkbox } from 'antd/es/checkbox'
 export { default as Divider } from 'antd/es/divider'

--- a/packages/react-saasify/src/themes/waves/index.js
+++ b/packages/react-saasify/src/themes/waves/index.js
@@ -12,6 +12,7 @@ export const waves = ({
   gradientDark = false,
   wave = true,
   codeBlockDark = false,
+  codeBlockOutputColor,
   ...opts
 } = {}) => {
   // Define root CSS vars
@@ -19,6 +20,10 @@ export const waves = ({
   const gradientTop = gradientDark
     ? 'rgba(0,0,0,0.35)'
     : 'rgba(158,143,143,0.50)'
+
+  const codeBlockBackground = codeBlockDark
+    ? '#2D2D2D'
+    : 'linear-gradient(174deg, #6e60e1 0%, #1b3b87 93%)'
 
   cv({
     'border-radius': buttonStyle === 'rounded' ? '100px' : '4px',
@@ -38,9 +43,8 @@ export const waves = ({
         : `url(${waveShadowedSvg})`
       : '',
     'color-nav-secondary-cta': backgroundImage ? 'white' : color,
-    'code-block-background': codeBlockDark
-      ? '#2D2D2D'
-      : 'linear-gradient(174deg, #6e60e1 0%, #1b3b87 93%)',
+    'code-block-background': codeBlockBackground,
+    'code-block-output-background': codeBlockOutputColor || codeBlockBackground,
     'code-block-shadow-color': codeBlockDark ? '#1E1E1E95' : '#392ab195',
     'hero-color': backgroundImage ? 'white' : '#3a3a3a',
     'nav-border-width': backgroundImage ? '0px' : '1px'

--- a/packages/react-saasify/src/themes/waves/waves.module.css
+++ b/packages/react-saasify/src/themes/waves/waves.module.css
@@ -709,6 +709,7 @@
 }
 
 .theme-waves .live-service-demo .output {
+  background: var(--code-block-output-background);
   max-height: 30vh;
   overflow-y: auto;
 }

--- a/packages/react-saasify/src/themes/waves/waves.module.css
+++ b/packages/react-saasify/src/themes/waves/waves.module.css
@@ -703,7 +703,7 @@
 }
 
 .theme-waves .live-service-demo .tab-content {
-  max-height: 25vh;
+  max-height: 32.5vh;
   position: static;
   overflow-y: auto;
 }
@@ -711,6 +711,10 @@
 .theme-waves .live-service-demo .output {
   max-height: 30vh;
   overflow-y: auto;
+}
+
+.theme-waves .live-service-demo .output img {
+  max-height: 30vh;
 }
 
 .theme-waves .code-block {


### PR DESCRIPTION
See commit history for diff. Visuals:

## enum input

<img width="511" alt="image" src="https://user-images.githubusercontent.com/985961/69026548-3487cb80-0980-11ea-888d-882de33578a0.png">


## Colored Output BG, and fixed size (thanks to medium zoom image)

<img width="585" alt="image" src="https://user-images.githubusercontent.com/985961/69026521-102bef00-0980-11ea-9454-550ec6396466.png">
