### PR TITLE
Better logo support

### DIFF
--- a/packages/react-saasify/src/components/Logo/Logo.js
+++ b/packages/react-saasify/src/components/Logo/Logo.js
@@ -7,7 +7,7 @@ import styles from './styles.module.css'
 
 export class Logo extends Component {
   render() {
-    const { className, style = {}, ...rest } = this.props
+    const { className, style = {}, light, ...rest } = this.props
 
     return (
       <SaasifyContext.Consumer>
@@ -15,7 +15,7 @@ export class Logo extends Component {
           config.logo ? (
             <img
               className={theme(styles, 'logo', className)}
-              src={config.logo}
+              src={(light && config.deployment.saas.logoLight) || config.logo}
               alt={`${config.name} Logo`}
               style={style}
               {...rest}

--- a/packages/react-saasify/src/components/NavHeader/NavHeader.js
+++ b/packages/react-saasify/src/components/NavHeader/NavHeader.js
@@ -86,7 +86,9 @@ export class NavHeader extends Component {
 
                   {config.logo && (
                     <span className={theme(styles, 'logo-text')}>
-                      {config.name}
+                      {typeof config.deployment.saas.headerName !== 'undefined'
+                        ? config.deployment.saas.headerName
+                        : config.name}
                     </span>
                   )}
                 </Link>

--- a/packages/react-saasify/src/components/NavHeader/NavHeader.js
+++ b/packages/react-saasify/src/components/NavHeader/NavHeader.js
@@ -82,6 +82,14 @@ export class NavHeader extends Component {
                 <Link to='/'>
                   <span className={theme(styles, 'logo-image')}>
                     <Logo className={theme(styles, 'logo')} />
+                    <Logo
+                      className={theme(
+                        styles,
+                        'logo',
+                        theme(styles, 'logo--light')
+                      )}
+                      light
+                    />
                   </span>
 
                   {config.logo && (

--- a/packages/react-saasify/src/components/NavHeader/styles.module.css
+++ b/packages/react-saasify/src/components/NavHeader/styles.module.css
@@ -48,6 +48,10 @@
   width: auto;
 }
 
+.logo--light {
+  display: none;
+}
+
 .logo-text {
   font-size: 22px;
   margin-right: 32px;

--- a/packages/react-saasify/src/themes/okta.module.css
+++ b/packages/react-saasify/src/themes/okta.module.css
@@ -146,3 +146,11 @@ body header + section:first-of-type .title {
 .theme-okta .docs-page header {
   background: #23303a !important;
 }
+
+.theme-okta .logo.logo--light {
+  display: flex;
+}
+
+.theme-okta .logo:not(.logo--light) {
+  display: none;
+}

--- a/packages/react-saasify/src/themes/waves/index.js
+++ b/packages/react-saasify/src/themes/waves/index.js
@@ -47,7 +47,9 @@ export const waves = ({
     'code-block-output-background': codeBlockOutputColor || codeBlockBackground,
     'code-block-shadow-color': codeBlockDark ? '#1E1E1E95' : '#392ab195',
     'hero-color': backgroundImage ? 'white' : '#3a3a3a',
-    'nav-border-width': backgroundImage ? '0px' : '1px'
+    'nav-border-width': backgroundImage ? '0px' : '1px',
+    'logo-light-top-display': backgroundImage ? 'flex' : 'none',
+    'logo-top-display': backgroundImage ? 'none' : 'flex'
   })
 
   // TODO: make styles more dynamic based on less variables

--- a/packages/react-saasify/src/themes/waves/waves.module.css
+++ b/packages/react-saasify/src/themes/waves/waves.module.css
@@ -575,6 +575,14 @@
   max-height: 48px;
 }
 
+.theme-waves header:not(.attached) .logo--light {
+  display: var(--logo-light-top-display);
+}
+
+.theme-waves header:not(.attached) .logo:not(.logo--light) {
+  display: var(--logo-top-display);
+}
+
 .theme-waves header .logo-text {
   font-weight: 600;
 }
@@ -1022,6 +1030,14 @@
 .theme-waves .docs-page header.expanded .logo-text:not(:hover),
 .theme-waves .docs-page header.expanded .links .link:not(:hover) {
   color: white !important;
+}
+
+.theme-waves .docs-page header.attached .logo--light {
+  display: flex;
+}
+
+.theme-waves .docs-page header.attached .logo:not(.logo--light) {
+  display: none;
 }
 
 .theme-waves .docs-page p {

--- a/packages/saasify-cli/lib/schemas/config.ts
+++ b/packages/saasify-cli/lib/schemas/config.ts
@@ -148,6 +148,7 @@ class SaaS {
   heading?: string
   subheading?: string
   logo?: string
+  logoLight?: string
   favicon?: string
   features?: Feature[]
   sections?: object


### PR DESCRIPTION
I've encountered these problems a few times, so thought I'd solve it for OG IMPACT. I wanted to:

1. Hide the name from the header - implemented `headerName` prop (set it to `""`). Not totally set on the name of this prop.
2. Show a different logo depending on the background color - implemented `logoLight` for use on dark backgrounds (such as waves image, or saasify social share images)

Tested in waves and okta.

## In use for OG IMPACT

### Top of page
<img width="1440" alt="Screenshot 2020-02-01 17 33 51" src="https://user-images.githubusercontent.com/985961/73596329-06467080-4519-11ea-84fa-590ebe68ed34.png">

### Scrolling

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/985961/73596334-12323280-4519-11ea-9bab-295e3944e974.png">

### No background image

<img width="1440" alt="Screenshot 2020-02-01 17 43 10" src="https://user-images.githubusercontent.com/985961/73596499-65f14b80-451a-11ea-9e58-29ba7200cc2d.png">
