### PR TITLE
Fix a globby option when parsing readme

### DIFF
--- a/packages/saasify-cli/lib/parse-project.js
+++ b/packages/saasify-cli/lib/parse-project.js
@@ -83,7 +83,7 @@ module.exports.getReadme = async (config) => {
     const readmeFiles = await globby('readme.md', {
       cwd: config.root,
       gitignore: true,
-      nocase: true
+      caseSensitiveMatch: false
     })
 
     if (readmeFiles.length) {


### PR DESCRIPTION
This PR tries to fix a bug when parsing readme file: its name should be case-insensitive, but it's not.

Globby has no `nocase` option, instead it has `caseSensitiveMatch`, like fast-glob. We need to use it instead.